### PR TITLE
Allow customizing checkbox true-value/false-value attrs

### DIFF
--- a/packages/runtime-core/src/apiCreateApp.ts
+++ b/packages/runtime-core/src/apiCreateApp.ts
@@ -166,6 +166,18 @@ export interface AppConfig {
    * Prefix for all useId() calls within this app
    */
   idPrefix?: string
+
+  /**
+   * Attribute name for checkbox true-value bindings used by v-model.
+   * Defaults to `"true-value"` for backwards compatibility.
+   */
+  vModelTrueValueAttr?: string
+
+  /**
+   * Attribute name for checkbox false-value bindings used by v-model.
+   * Defaults to `"false-value"` for backwards compatibility.
+   */
+  vModelFalseValueAttr?: string
 }
 
 export interface AppContext {
@@ -232,6 +244,8 @@ export function createAppContext(): AppContext {
       errorHandler: undefined,
       warnHandler: undefined,
       compilerOptions: {},
+      vModelTrueValueAttr: 'true-value',
+      vModelFalseValueAttr: 'false-value',
     },
     mixins: [],
     components: {},

--- a/packages/runtime-dom/__tests__/directives/vModel.spec.ts
+++ b/packages/runtime-dom/__tests__/directives/vModel.spec.ts
@@ -1,5 +1,6 @@
 import {
   type VNode,
+  createApp,
   defineComponent,
   h,
   nextTick,
@@ -587,6 +588,41 @@ describe('vModel', () => {
     triggerEvent('change', input)
     await nextTick()
     expect(data.value).toEqual({ no: 'no' })
+  })
+
+  it('should allow customizing true-value/false-value attribute names via config', async () => {
+    const component = defineComponent({
+      data() {
+        return { value: 'yes' }
+      },
+      render() {
+        return [
+          withVModel(
+            h('input', {
+              type: 'checkbox',
+              'data-true-value': 'yes',
+              'data-false-value': 'no',
+              'onUpdate:modelValue': setValue.bind(this),
+            }),
+            this.value,
+          ),
+        ]
+      },
+    })
+    const app = createApp(component)
+    app.config.vModelTrueValueAttr = 'data-true-value'
+    app.config.vModelFalseValueAttr = 'data-false-value'
+    app.mount(root)
+
+    const input = root.querySelector('input')!
+    const data = root._vnode!.component!.data
+
+    expect(input.checked).toEqual(true)
+
+    input.checked = false
+    triggerEvent('change', input)
+    await nextTick()
+    expect(data.value).toEqual('no')
   })
 
   it(`should support array as a checkbox model`, async () => {

--- a/packages/runtime-dom/src/patchProp.ts
+++ b/packages/runtime-dom/src/patchProp.ts
@@ -65,12 +65,17 @@ export const patchProp: DOMRendererOptions['patchProp'] = (
     patchDOMProp(el, camelize(key), nextValue, parentComponent, key)
   } else {
     // special case for <input v-model type="checkbox"> with
-    // :true-value & :false-value
+    // true-value & false-value (configurable)
     // store value as dom properties since non-string values will be
     // stringified.
-    if (key === 'true-value') {
+    const config = parentComponent
+      ? parentComponent.appContext.config
+      : undefined
+    const trueAttr = (config && config.vModelTrueValueAttr) || 'true-value'
+    const falseAttr = (config && config.vModelFalseValueAttr) || 'false-value'
+    if (key === trueAttr) {
       ;(el as any)._trueValue = nextValue
-    } else if (key === 'false-value') {
+    } else if (key === falseAttr) {
       ;(el as any)._falseValue = nextValue
     }
     patchAttr(el, key, nextValue, isSVG, parentComponent)


### PR DESCRIPTION
## Summary
- expose `vModelTrueValueAttr` and `vModelFalseValueAttr` in `AppConfig`
- use configured attribute names in `patchProp`
- test configurable true/false value attributes

## Testing
- `pnpm lint`
- `pnpm exec vitest run --project unit`

------
https://chatgpt.com/codex/tasks/task_e_687fd9934660832a95da838671fe10b8